### PR TITLE
[ #70, Link improvements ]

### DIFF
--- a/src/lib/parseFile.ts
+++ b/src/lib/parseFile.ts
@@ -98,7 +98,9 @@ export const extractWikiLinks = (ast: Root, options?: ParsingOptions) => {
   const extractors: LinkExtractors = {
     link: (node: any) => {
       const to = !node.url.startsWith("http")
-        ? path.posix.join(directory, node.url)
+        ? node.url.startsWith("/")
+          ? node.url.slice(1)
+          : path.posix.join(directory, node.url)
         : node.url;
       return {
         from: from,
@@ -111,7 +113,9 @@ export const extractWikiLinks = (ast: Root, options?: ParsingOptions) => {
     },
     image: (node: any) => ({
       from: from,
-      to: path.posix.join(directory, node.url),
+      to: node.url.startsWith("/")
+        ? node.url.slice(1)
+        : path.posix.join(directory, node.url),
       toRaw: node.url,
       text: node.alt || "",
       embed: true,
@@ -133,7 +137,9 @@ export const extractWikiLinks = (ast: Root, options?: ParsingOptions) => {
         text = node.children?.[0]?.value || "";
       }
       const to = !linkSrc.startsWith("http")
-        ? path.posix.join(directory, linkSrc)
+        ? linkSrc.startsWith("/")
+          ? linkSrc.slice(1)
+          : path.posix.join(directory, linkSrc)
         : linkSrc;
 
       return {

--- a/src/tests/extractWikiLinks.spec.ts
+++ b/src/tests/extractWikiLinks.spec.ts
@@ -61,13 +61,28 @@ describe("extractWikiLinks", () => {
       expect(links).toEqual(expectedLinks);
     });
 
-    test("should extract CommonMark links with absolute path", () => {
-      const links = getLinksFromSource("[hello](/world)");
+    test("should extract CommonMark links with relative path", () => {
+      const links = getLinksFromSource("[hello](./world.md)");
       const expectedLinks = [
         {
           from: "abc/foobar.md",
-          to: "abc/world",
-          toRaw: "/world",
+          to: "abc/world.md",
+          toRaw: "./world.md",
+          text: "hello",
+          embed: false,
+          internal: true,
+        },
+      ];
+      expect(links).toEqual(expectedLinks);
+    });
+
+    test("should extract CommonMark links with absolute path", () => {
+      const links = getLinksFromSource("[hello](/world.md)");
+      const expectedLinks = [
+        {
+          from: "abc/foobar.md",
+          to: "world.md",
+          toRaw: "/world.md",
           text: "hello",
           embed: false,
           internal: true,
@@ -158,7 +173,7 @@ describe("extractWikiLinks", () => {
           from: "abc/foobar.md",
           internal: true,
           text: "",
-          to: "abc/some/folder/Page 1",
+          to: "some/folder/Page 1",
           toRaw: "/some/folder/Page 1",
         },
         {
@@ -166,7 +181,7 @@ describe("extractWikiLinks", () => {
           from: "abc/foobar.md",
           internal: true,
           text: "",
-          to: "abc/some/folder/Page 2",
+          to: "some/folder/Page 2",
           toRaw: "/some/folder/Page 2",
         },
         {
@@ -174,7 +189,7 @@ describe("extractWikiLinks", () => {
           from: "abc/foobar.md",
           internal: true,
           text: "",
-          to: "abc/some/folder/Page 3",
+          to: "some/folder/Page 3",
           toRaw: "/some/folder/Page 3",
         },
       ];


### PR DESCRIPTION
fix absolute paths to refer to root folder instead `/world.md` => `world.md`