### PR TITLE
Parse and store list names for tasks in Kanban Board documents

### DIFF
--- a/src/lib/databaseUtils.ts
+++ b/src/lib/databaseUtils.ts
@@ -93,6 +93,7 @@ export function mapTasksToInsert(file: any) {
       due: task.due,
       completion: task.completion,
       start: task.start,
+      list: task.list,
       scheduled: task.scheduled,
     };
   });

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -317,6 +317,7 @@ interface Task {
   created: string;
   start: string | null;
   scheduled: string | null;
+  list: string | null;
   metadata: MetaData | null;
 
 }
@@ -330,6 +331,7 @@ class MddbTask {
   created: string;
   start: string | null;
   scheduled: string | null;
+  list: string | null;
   metadata: MetaData | null;
 
   constructor(task: Task) {
@@ -340,6 +342,7 @@ class MddbTask {
     this.created = task.created;
     this.start = task.start;
     this.scheduled = task.scheduled;
+    this.list = task.list;
     this.metadata = task.metadata;
   }
 
@@ -353,6 +356,7 @@ class MddbTask {
       table.string("created");
       table.string("start");
       table.string("scheduled");
+      table.string("list");
       table.string("metadata");
     };
     const tableExists = await db.schema.hasTable(this.table);

--- a/src/tests/computedField.spec.ts
+++ b/src/tests/computedField.spec.ts
@@ -66,6 +66,7 @@ describe("Can parse a file and get file info", () => {
                     completion: null,
                     start: null,
                     scheduled: null,
+                    list: null,
                 },
                 {
                     checked: true,
@@ -76,6 +77,7 @@ describe("Can parse a file and get file info", () => {
                     completion: null,
                     start: null,
                     scheduled: null,
+                    list: null,
                 },
                 {
                     checked: true,
@@ -86,6 +88,7 @@ describe("Can parse a file and get file info", () => {
                     completion: null,
                     start: null,
                     scheduled: null,
+                    list: null,
                 },
             ],
         });
@@ -219,6 +222,7 @@ describe("Can parse a file and get file info", () => {
                     completion: null,
                     start: null,
                     scheduled: null,
+                    list: null,
                 },
                 {
                     checked: true,
@@ -229,6 +233,7 @@ describe("Can parse a file and get file info", () => {
                     completion: null,
                     start: null,
                     scheduled: null,
+                    list: null,
                 },
                 {
                     checked: true,
@@ -239,6 +244,7 @@ describe("Can parse a file and get file info", () => {
                     completion: null,
                     start: null,
                     scheduled: null,
+                    list: null,
                 },
             ],
         });
@@ -303,7 +309,7 @@ describe("Can parse a file and get file info", () => {
                     completion: null,
                     start: null,
                     scheduled: null,
-
+                    list: null,
                 },
                 {
                     checked: true,
@@ -314,6 +320,7 @@ describe("Can parse a file and get file info", () => {
                     completion: null,
                     start: null,
                     scheduled: null,
+                    list: null,
                 },
                 {
                     checked: true,
@@ -324,6 +331,7 @@ describe("Can parse a file and get file info", () => {
                     completion: null,
                     start: null,
                     scheduled: null,
+                    list: null,
                 },
             ],
         });

--- a/src/tests/extractTasks.spec.ts
+++ b/src/tests/extractTasks.spec.ts
@@ -1,8 +1,10 @@
+import matter from "gray-matter";
 import { extractTasks, processAST } from "../lib/parseFile";
 
 const getTasksFromSource = (source: string) => {
   const ast = processAST(source, {});
-  const tasks = extractTasks(ast);
+  const { data: metadata } = matter(source);
+  const tasks = extractTasks(ast, metadata);
   return tasks;
 };
 
@@ -18,7 +20,8 @@ describe("extractTasks", () => {
       due: null,
       completion: null,
       start: null,
-      scheduled: null,  },
+      scheduled: null,
+      list: null,  },
     ];
     expect(tasks).toEqual(expectedTasks);
   });
@@ -33,13 +36,15 @@ describe("extractTasks", () => {
       due: null,
       completion: null,
       start: null,
-      scheduled: null,  },
+      scheduled: null,
+      list: null,  },
       { description: "completed task 2", checked: true, metadata: {}, 
       created: null,
       due: null,
       completion: null,
       start: null,
-      scheduled: null,  },
+      scheduled: null,
+      list: null,  },
     ];
     expect(tasks).toEqual(expectedTasks);
   });
@@ -54,13 +59,15 @@ describe("extractTasks", () => {
       due: null,
       completion: null,
       start: null,
-      scheduled: null,  },
+      scheduled: null,
+      list: null,  },
       { description: "uncompleted task", checked: false, metadata: {}, 
       created: null,
       due: null,
       completion: null,
       start: null,
-      scheduled: null,  },
+      scheduled: null,
+      list: null,  },
     ];
     expect(tasks).toEqual(expectedTasks);
   });
@@ -75,13 +82,15 @@ describe("extractTasks", () => {
       due: null,
       completion: null,
       start: null,
-      scheduled: null,  },
+      scheduled: null,
+      list: null,  },
       { description: "uncompleted task", checked: false, metadata: {}, 
       created: null,
       due: null,
       completion: null,
       start: null,
-      scheduled: null,  },
+      scheduled: null,
+      list: null,  },
     ];
     expect(tasks).toEqual(expectedTasks);
   });
@@ -96,19 +105,22 @@ describe("extractTasks", () => {
       due: null,
       completion: null,
       start: null,
-      scheduled: null, },
+      scheduled: null,
+      list: null, },
       { description: "task 2", checked: true, metadata: {}, 
       created: null,
       due: null,
       completion: null,
       start: null,
-      scheduled: null,  },
+      scheduled: null,
+      list: null,  },
       { description: "task 3", checked: false, metadata: {}, 
       created: null,
       due: null,
       completion: null,
       start: null,
-      scheduled: null,  },
+      scheduled: null,
+      list: null,  },
     ];
     expect(tasks).toEqual(expectedTasks);
   });
@@ -125,6 +137,7 @@ describe("extractTasks", () => {
         completion: null,
         start: null,
         scheduled: null, 
+        list: null,
       },
     ];
     expect(tasks).toEqual(expectedTasks);
@@ -143,9 +156,29 @@ describe("extractTasks", () => {
         completion: null,
         start: null,
         scheduled: null,
-      
+        list: null,
       },
     ];
     expect(tasks).toEqual(expectedTasks);
+  });
+  test("should extract tasks with kanban list names from body", () => {
+    const body = "## Ideas\n\n- [ ] task 1\n- [ ] task 2\n## Doing\n\n- [ ] task 3\n- [ ] task 4\n## Done\n\n- [x] task 5";
+    const kanbanMetadata = "---\nkanban-list: board\n---\n";
+    const tasksInNonKanban = getTasksFromSource(body);
+    const tasksInKanban = getTasksFromSource(kanbanMetadata + body);
+    expect(tasksInNonKanban).toEqual([
+      { description: "task 1", checked: false, metadata: {}, created: null, due: null, completion: null, start: null, scheduled: null, list: null },
+      { description: "task 2", checked: false, metadata: {}, created: null, due: null, completion: null, start: null, scheduled: null, list: null },
+      { description: "task 3", checked: false, metadata: {}, created: null, due: null, completion: null, start: null, scheduled: null, list: null },
+      { description: "task 4", checked: false, metadata: {}, created: null, due: null, completion: null, start: null, scheduled: null, list: null },
+      { description: "task 5", checked: true, metadata: {}, created: null, due: null, completion: null, start: null, scheduled: null, list: null },
+    ]);
+    expect(tasksInKanban).toEqual([
+      { description: "task 1", checked: false, metadata: {}, created: null, due: null, completion: null, start: null, scheduled: null, list: "Ideas" },
+      { description: "task 2", checked: false, metadata: {}, created: null, due: null, completion: null, start: null, scheduled: null, list: "Ideas" },
+      { description: "task 3", checked: false, metadata: {}, created: null, due: null, completion: null, start: null, scheduled: null, list: "Doing" },
+      { description: "task 4", checked: false, metadata: {}, created: null, due: null, completion: null, start: null, scheduled: null, list: "Doing" },
+      { description: "task 5", checked: true, metadata: {}, created: null, due: null, completion: null, start: null, scheduled: null, list: "Done" },
+    ]);
   });
 });

--- a/src/tests/parseFile.spec.ts
+++ b/src/tests/parseFile.spec.ts
@@ -60,6 +60,7 @@ describe("parseFile", () => {
           completion: null,
           start: null,
           scheduled: null,
+          list: null,
         },
         { 
           description: "completed task", 
@@ -70,6 +71,7 @@ describe("parseFile", () => {
           completion: null,
           start: null,
           scheduled: null,
+          list: null,
         },
       ],
     };
@@ -138,6 +140,7 @@ describe("parseFile", () => {
           completion: null,
           start: null,
           scheduled: null,
+          list: null,
       },
         { 
           description: "completed task", 
@@ -148,6 +151,7 @@ describe("parseFile", () => {
           completion: null,
           start: null,
           scheduled: null,
+          list: null,
         },
       ],
     };

--- a/src/tests/process.spec.ts
+++ b/src/tests/process.spec.ts
@@ -52,6 +52,7 @@ describe("Can parse a file and get file info", () => {
           completion: null,
           start: null,
           scheduled: null,
+          list: null,
         },
         {
           checked: true,
@@ -62,6 +63,7 @@ describe("Can parse a file and get file info", () => {
           completion: null,
           start: null,
           scheduled: null,
+          list: null,
         },
         {
           checked: true,
@@ -72,6 +74,7 @@ describe("Can parse a file and get file info", () => {
           completion: null,
           start: null,
           scheduled: null,
+          list: null,
         },
       ],
     });


### PR DESCRIPTION
I'm a long-time user of the [Kanban](https://github.com/mgmeyers/obsidian-kanban) plugin and I just happened to come across this wonderful project.  In my use case, it would be helpful to be able to use the list names when querying Kanban tasks, so I created this PR.

I could change the name to `kanban_list` if `list` sounds too generic and no other task management plugin has a concept of a "list name".