### PR TITLE
Add a prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "tsc --p tsconfig.lib.json",
     "watch": "tsc --p tsconfig.lib.json --watch",
     "changeset": "changeset",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "release": "changeset publish"
   },


### PR DESCRIPTION
This allows users to install mddb via `npm install -g github:flowershow/markdowndb` or directly run it like so: `npx github:flowershow/markdowndb`.